### PR TITLE
Added __future__ import for type annotation support in Python 3.7 and…

### DIFF
--- a/src/requests_oidc/flows/utils.py
+++ b/src/requests_oidc/flows/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import time
 
 

--- a/src/requests_oidc/plugins.py
+++ b/src/requests_oidc/plugins.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 import json
 import appdirs


### PR DESCRIPTION
… 3.8

This change is only reflected in currently problematic files.